### PR TITLE
Nits

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,12 +1,2 @@
-/coverage
-/examples
-/lib/test
-/src
-/test
-/.editorconfig
-/.gitignore
-/.travis.yml
-/tsconfig.json
-/tslint.json
-/doc
-/logo.png
+*
+!/lib

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,8 @@
+sudo: required
+language: node_js
+node_js:
+  - 6
+services:
+  - docker
+before_install:
+  - docker run --name etcd-v3.0.9 -d -v /data/etcd/:/data -p 2379:2379 xieyanze/etcd3:latest

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,4 +5,5 @@ node_js:
 services:
   - docker
 before_install:
+  - npm i -g npm
   - docker run --name etcd-v3.0.9 -d -v /data/etcd/:/data -p 2379:2379 xieyanze/etcd3:latest

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,4 +6,4 @@ services:
   - docker
 before_install:
   - npm i -g npm
-  - docker run --name etcd-v3.0.9 -d -v /data/etcd/:/data -p 2379:2379 xieyanze/etcd3:latest
+  - docker run -d -p 2379:2379 -p 2380:2380 appcelerator/etcd

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,11 @@
-sudo: required
 language: node_js
 node_js:
   - 6
-services:
-  - docker
+env:
+  - ETCD_VER=v3.1.5
 before_install:
+  - curl -L https://github.com/coreos/etcd/releases/download/${ETCD_VER}/etcd-${ETCD_VER}-linux-amd64.tar.gz -o /tmp/etcd-${ETCD_VER}-linux-amd64.tar.gz
+  - mkdir -p /tmp/etcd
+  - tar xzvf /tmp/etcd-${ETCD_VER}-linux-amd64.tar.gz -C /tmp/etcd --strip-components=1
+  - /tmp/etcd/etcd > /dev/null &
   - npm i -g npm
-  - docker run -d -p 2379:2379 -p 2380:2380 appcelerator/etcd

--- a/package.json
+++ b/package.json
@@ -2,12 +2,14 @@
   "name": "etcd3",
   "version": "0.1.0",
   "description": "Node client for etcd3",
-  "main": "dist/index.js",
+  "main": "lib/src/index.js",
   "scripts": {
     "test": "npm-run-all --parallel test:lint test:unit",
     "test:unit": "mocha --compilers ts:ts-node/register --timeout 20000 -r test/_setup.ts test/*.test.ts",
     "test:lint": "tslint --type-check --project tsconfig.json '{src,test}/**/*.ts'",
-    "update-proto": "node ./bin/update-proto ./proto && node bin/generate-methods.js ./proto/rpc.proto > src/rpc.ts"
+    "update-proto": "node ./bin/update-proto ./proto && node bin/generate-methods.js ./proto/rpc.proto > src/rpc.ts",
+    "build": "tsc",
+    "prepublish": "tsc"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -3,13 +3,14 @@
   "version": "0.1.0",
   "description": "Node client for etcd3",
   "main": "lib/src/index.js",
+  "typings": "lib/src/index.d.ts",
   "scripts": {
     "test": "npm-run-all --parallel test:lint test:unit",
     "test:unit": "mocha --compilers ts:ts-node/register --timeout 20000 -r test/_setup.ts test/*.test.ts",
     "test:lint": "tslint --type-check --project tsconfig.json '{src,test}/**/*.ts'",
     "update-proto": "node ./bin/update-proto ./proto && node bin/generate-methods.js ./proto/rpc.proto > src/rpc.ts",
-    "build": "tsc",
-    "prepublish": "tsc"
+    "build": "tsc && cp -R proto lib",
+    "prepublish": "npm run -s build"
   },
   "repository": {
     "type": "git",

--- a/readme.md
+++ b/readme.md
@@ -1,6 +1,6 @@
 # etcd3
 
-etcd3 aims to be (with its first stable release) a high-quality, production-ready client for the Protocol Buffer-based etcdv3 API. It includes load balancing, reconnections, high-level query builders and lease management, and is type-safe for TypeScript consumers.
+etcd3 aims to be (with its first stable release) a high-quality, production-ready client for the Protocol Buffer-based etcdv3 API. It includes load balancing, reconnections, high-level query builders and lease management, mocking, and is type-safe for TypeScript consumers.
 
 ### Quickstart
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -62,6 +62,23 @@ export class Etcd3 {
   }
 
   /**
+   * mock allows you to insert an interface that will be called into instead
+   * of calling out to the "real" service. `unmock` should be called after
+   * mocking is finished.
+   */
+  public mock<T extends RPC.ICallable>(callable: T): T {
+    this.pool.mock(callable);
+    return callable;
+  }
+
+  /**
+   * Removes any previously-inserted mock.
+   */
+  public unmock(): void {
+    return this.pool.unmock();
+  }
+
+  /**
    * Frees resources associated with the client.
    */
   public close() {

--- a/src/index.ts
+++ b/src/index.ts
@@ -75,7 +75,7 @@ export class Etcd3 {
    * Removes any previously-inserted mock.
    */
   public unmock(): void {
-    return this.pool.unmock();
+    this.pool.unmock();
   }
 
   /**

--- a/src/kv-builder.ts
+++ b/src/kv-builder.ts
@@ -125,8 +125,8 @@ export class SingleRangeBuilder extends RangeBuilder {
    * Runs the built request and parses the returned key as JSON,
    * or returns `null` if it isn't found.
    */
-  public json(): Promise<any> {
-    return this.string().then(value => value === null ? null : JSON.parse(value));
+  public json(): Promise<object> {
+    return this.string().then(JSON.parse);
   }
 
   /**
@@ -225,8 +225,8 @@ export class MultiRangeBuilder extends RangeBuilder {
   /**
    * Runs the built request and parses the returned keys as JSON.
    */
-  public json(): Promise<any> {
-    return this.buffers().then(res => res.map(value => JSON.stringify(value)));
+  public json(): Promise<object> {
+    return this.buffers().then(res => res.map(value => JSON.parse(value.toString())));
   }
 
   /**

--- a/src/shared-pool.ts
+++ b/src/shared-pool.ts
@@ -72,7 +72,15 @@ export class SharedPool<T> {
    */
   public fail(resource: T) {
     const record = this.recordFor(resource);
-    record.availableAfter = Date.now() + record.backoff.getDelay();
+    const now = Date.now();
+
+    // If multiple callers are using a resource when it fails, they'll
+    // probably all fail it at once. Only take the first one.
+    if (record.availableAfter > now) {
+      return;
+    }
+
+    record.availableAfter = now + record.backoff.getDelay();
     record.backoff = record.backoff.next();
   }
 

--- a/test/kv.test.ts
+++ b/test/kv.test.ts
@@ -61,7 +61,7 @@ describe('connection pool', () => {
     });
 
     it('gets keys', async () => {
-      expect(await client.getAll().keys()).to.have.members(['foo1', 'foo2', 'foo3', 'baz']);
+      expect(await client.getAll().keys().strings()).to.have.members(['foo1', 'foo2', 'foo3', 'baz']);
     });
 
     it('counts', async () => {
@@ -73,14 +73,16 @@ describe('connection pool', () => {
         .prefix('foo')
         .sort('key', 'asc')
         .limit(2)
-        .keys(),
+        .keys()
+        .strings(),
       ).to.deep.equal(['foo1', 'foo2']);
 
       expect(await client.getAll()
         .prefix('foo')
         .sort('key', 'desc')
         .limit(2)
-        .keys(),
+        .keys()
+        .strings(),
       ).to.deep.equal(['foo3', 'foo2']);
     });
   });
@@ -93,7 +95,7 @@ describe('connection pool', () => {
 
     it('deletes prefix', async () => {
       await client.delete().prefix('foo');
-      expect(await client.getAll().keys()).to.deep.equal(['baz']);
+      expect(await client.getAll().keys().strings()).to.deep.equal(['baz']);
     });
 
     it('gets previous', async () => {

--- a/test/kv.test.ts
+++ b/test/kv.test.ts
@@ -30,6 +30,19 @@ describe('connection pool', () => {
     badClient.close();
   });
 
+  it('allows mocking', async () => {
+    const mock = client.mock({
+      exec: sinon.stub(),
+      getConnection: sinon.stub(),
+    });
+
+    mock.exec.resolves({ kvs: [] });
+    expect(await client.get('foo1').string()).to.be.null;
+    expect(mock.exec.calledWith('KV', 'range')).to.be.true;
+    client.unmock();
+    expect(await client.get('foo1').string()).to.equal('bar1');
+  });
+
   describe('get() / getAll()', () => {
     it('lists all values', async () => {
       expect(await client.getAll().strings()).to.containSubset(['bar1', 'bar2', 'bar5']);

--- a/test/shared-pool.test.ts
+++ b/test/shared-pool.test.ts
@@ -67,10 +67,11 @@ describe('shared pool', () => {
   });
 
   it('should not back off multiple times if multiple callers fail', async () => {
+    const getFirstBackoff = (): number => (<any> pool).resources[0].availableAfter;
     const cnx = await pool.pull();
     pool.fail(cnx);
-    expect((<any> pool).resources[0].availableAfter).to.equal(Date.now() + 500);
+    expect(getFirstBackoff()).to.equal(Date.now() + 500);
     pool.fail(cnx);
-    expect((<any> pool).resources[0].availableAfter).to.equal(Date.now() + 500);
+    expect(getFirstBackoff()).to.equal(Date.now() + 500);
   });
 });

--- a/test/shared-pool.test.ts
+++ b/test/shared-pool.test.ts
@@ -65,4 +65,12 @@ describe('shared pool', () => {
     clock.tick(500);
     expect(await getAll()).to.deep.equal([0, 2, 1]);
   });
+
+  it('should not back off multiple times if multiple callers fail', async () => {
+    const cnx = await pool.pull();
+    pool.fail(cnx);
+    expect((<any> pool).resources[0].availableAfter).to.equal(Date.now() + 500);
+    pool.fail(cnx);
+    expect((<any> pool).resources[0].availableAfter).to.equal(Date.now() + 500);
+  });
 });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,7 +7,6 @@
     "noUnusedLocals": true,
     "noUnusedParameters": true,
     "strictNullChecks": true,
-    "declaration": true,
 		"module": "commonjs",
 		"target": "es6",
 		"outDir": "lib",
@@ -17,6 +16,7 @@
     ]
 	},
   "exclude": [
-    "node_modules"
+    "node_modules",
+    "lib"
   ]
 }


### PR DESCRIPTION
Some minor tweaks that I thought of overnight. One per commit.

 - Added a simple mocking implementation that can make testing in certain scenarios easier.
 - Fixed a case where we would likely end up backing off more than we should.
 - Make `key()` chainable, whereas in the past someone could _only_ request the keys as strings.
 - Allowed clients to set the encoding in  the `string()` and `strings()` methods